### PR TITLE
Add docker development support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:13.10-stretch
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+COPY . .
+
+RUN npm install
+
+EXPOSE 3000
+
+CMD ["npm", "start"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build-docker:
+	docker build -t findcovidtesting:latest .
+
+run-docker:
+	docker run -p 8080:3000 -d findcovidtesting

--- a/README.md
+++ b/README.md
@@ -14,6 +14,19 @@ Run tests:
 
 `npm test`
 
+## Local Development with Docker
+
+Pre-reqs:
+    1. docker installed
+        Check with `docker version`
+    2. make installed (if using provided Makefile)
+
+Run `docker build -t findcovidtesting:latest .`manually or use
+    `make build-docker`
+
+Run `docker run -p 8080:3000 -d findcovidtesting` manually or use
+    `make run-docker`
+
 ## Development and Deploying
 
 * Develop locally in a feature branch


### PR DESCRIPTION
Remove dependency barriers to entry for dev.

Speed up building and testing for dev.

as there are no code changes to push to staging I am opening against master (please let me know if i should go through the trouble of re-basing against develop and opening a new PR)