### PR TITLE
Fixes 100vh not working as expected in Mobile Safari

### DIFF
--- a/src/Components/AppBar.tsx
+++ b/src/Components/AppBar.tsx
@@ -1,52 +1,31 @@
 import React from 'react';
-import styled from 'styled-components';
 import MuiAppBar from '@material-ui/core/AppBar';
 import Toolbar from '@material-ui/core/Toolbar';
 import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
 import Tooltip from '@material-ui/core/Tooltip';
-
-import { createStyles, makeStyles, Theme } from '@material-ui/core/styles';
-import { Fab } from '@material-ui/core';
+import Fab from '@material-ui/core/Fab';
 import AssistantIcon from '@material-ui/icons/Assistant';
+import styled from 'styled-components';
 import MoreButton from './MoreButton';
 import { ADD_LOCATION_FORM } from '../constants';
 
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    text: {
-      padding: theme.spacing(2, 2, 0),
-    },
-    paper: {
-      paddingBottom: 50,
-    },
-    list: {
-      marginBottom: theme.spacing(2),
-    },
-    subheader: {
-      backgroundColor: theme.palette.background.paper,
-    },
-    appBar: {
-      top: 'auto',
-      bottom: 0,
-      height: '60px',
-    },
-    grow: {
-      flexGrow: 1,
-    },
-    fabButton: {
-      position: 'absolute',
-      zIndex: 1,
-      top: -30,
-      left: 0,
-      right: 0,
-      margin: '0 auto',
-    },
-    searchContainer: {
-      position: 'relative',
-    },
-  })
-);
+const SearchContainer = styled.div`
+  position: relative;
+`;
+
+const ActionButtonContainer = styled.div`
+  position: absolute;
+  z-index: 1;
+  top: -24px;
+  left: 50%;
+  transform: translate(-50%, 0);
+`;
+
+const Spacer = styled.div`
+  flex-grow: 1;
+  flex-basis: 100%;
+`;
 
 type AppBarProps = {
   geocoderContainerRef: any;
@@ -54,24 +33,20 @@ type AppBarProps = {
 };
 
 const AppBar = (props: AppBarProps) => {
-  const classes = useStyles();
-
   const { geocoderContainerRef, toggleDrawer } = props;
 
   return (
-    <MuiAppBar position="fixed" color="default" className={classes.appBar}>
+    <MuiAppBar position="relative" color="default">
       <Toolbar>
-        <div className={classes.searchContainer} ref={geocoderContainerRef} />
+        <SearchContainer ref={geocoderContainerRef} />
 
-        <Fab
-          onClick={toggleDrawer}
-          className={classes.fabButton}
-          color="primary"
-        >
-          <AssistantIcon />
-        </Fab>
+        <ActionButtonContainer>
+          <Fab onClick={toggleDrawer} color="primary">
+            <AssistantIcon />
+          </Fab>
+        </ActionButtonContainer>
 
-        <div className={classes.grow} />
+        <Spacer />
 
         <Tooltip title="Add a new location" placement="top" arrow>
           <IconButton

--- a/src/Components/LocationDetails.tsx
+++ b/src/Components/LocationDetails.tsx
@@ -30,7 +30,6 @@ import Link from '@material-ui/core/Link';
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import { IconProp } from '@fortawesome/fontawesome-svg-core';
-import LocationModal from './LocationModal';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({

--- a/src/Components/Map.tsx
+++ b/src/Components/Map.tsx
@@ -53,7 +53,7 @@ const Map = (props: MapProps) => {
   return (
     <ReactMapGL
       width="100%"
-      height="calc(100% - 54px)"
+      height="100%"
       viewState={viewState}
       getCursor={() => 'cursor'}
       onViewStateChange={setViewState}

--- a/src/utils/getViewportHeight.tsx
+++ b/src/utils/getViewportHeight.tsx
@@ -1,0 +1,8 @@
+// calculate browser height
+const getViewportHeight = (): number =>
+  (document &&
+    document.documentElement &&
+    document.documentElement.clientHeight) ||
+  window.innerHeight;
+
+export default getViewportHeight;


### PR DESCRIPTION
Note: Do some cross-browser testing on this before approving

This is primarily focused on fixing some cross-browser issues (primarily in Safari and Mobile Safari) relating to the positioning of the map and app bar components. The goal is to have the app fixed-height to the size of the browser, with the map taking up all of the middle area, sandwiched between the info prompt (top) and the app bar (bottom). One monkeywrench was that Mobile Safari has its own bottom-fixed app bar that appears on load and shows/hides as the user scrolls down the page, but doesn't change the height as detected by `100vh` in CSS, so in Mobile Safari the map was sizing improperly and conflicting with the app bar positioning. There were a couple of different attempts we made at trying to alleviate this, including making the app bar sticky or fixed positioned, but this led to the map being too big and having map controls like zoom and geolocation hidden behind the fixed-positioned app bar. Ultimately the solution I rested on was just using JS to detect the available browser height and using that instead of relying on `100vh` for our layout. This lets us arrange components on the page intuitively using flexbox and not having to use `calc` on the map or set the app bar to fixed/sticky.