### PR TITLE
Change report a problem link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/ENV

--- a/src/Components/LocationModal/LocationActions.tsx
+++ b/src/Components/LocationModal/LocationActions.tsx
@@ -14,6 +14,9 @@ interface LocationActionsProps {
 }
 
 const LocationActions = ({ location, onLinkClick }: LocationActionsProps) => {
+  const raw_attributes = JSON.parse(location.raw_data);
+  
+  
   return (
     <div>
       {location.location_contact_phone_main !== null &&
@@ -54,11 +57,11 @@ const LocationActions = ({ location, onLinkClick }: LocationActionsProps) => {
       <Tooltip title="Report an error" placement="top" arrow>
         <IconButton
           area-label="report"
-          href="https://docs.google.com/forms/d/e/1FAIpQLSd2xzEXfJdNJIGh5MDhxg217-p_MXvSREOuQT_P_vwrqSjEMQ/viewform?usp=sf_link"
+          href={`https://survey123.arcgis.com/share/913cbc92618746d3adf3c54b38798df7?mode=edit&globalId=${raw_attributes.global_id}&field:name=${encodeURIComponent(location.location_name)}`}
           target="_blank"
           rel="noopener"
           onClick={() => {
-            onLinkClick(location.location_id, 'Report Error');
+            onLinkClick(`${location.location_name}|${location.location_latitude},${location.location_longitude}|${location.global_id}`, 'Report Error');
           }}
         >
           <ReportProblemIcon />


### PR DESCRIPTION
Per GISCorps request, the "report a problem" form now points to their custom form, and passes the requisite parameters to make it easier to track changes on their end.